### PR TITLE
fix: cancel ask flow on ctrl-c

### DIFF
--- a/src/ask-inline-ui.ts
+++ b/src/ask-inline-ui.ts
@@ -206,6 +206,11 @@ export async function askSingleQuestionWithInlineNote(
 		};
 
 		const handleInput = (data: string) => {
+			if (matchesKey(data, Key.ctrl("c"))) {
+				done({ cancelled: true });
+				return;
+			}
+
 			if (isNoteEditorOpen) {
 				if (matchesKey(data, Key.tab) || matchesKey(data, Key.escape)) {
 					isNoteEditorOpen = false;

--- a/src/ask-tabs-ui.ts
+++ b/src/ask-tabs-ui.ts
@@ -438,6 +438,11 @@ export async function askQuestionsWithTabs(
 		};
 
 		const handleInput = (data: string) => {
+			if (matchesKey(data, Key.ctrl("c"))) {
+				done(createTabsUiStateSnapshot(true, selectedOptionIndexesByQuestion, noteByQuestionByOption));
+				return;
+			}
+
 			if (isNoteEditorOpen) {
 				if (matchesKey(data, Key.tab) || matchesKey(data, Key.escape)) {
 					isNoteEditorOpen = false;

--- a/test/ask-ui-interaction.test.ts
+++ b/test/ask-ui-interaction.test.ts
@@ -277,7 +277,7 @@ describe("askQuestionsWithTabs interactive branches", () => {
 		});
 	});
 
-	it("cancels tab flow on Ctrl-C from question, note editor, and submit tab", async () => {
+	it("cancels tab flow on Ctrl-C from note editor", async () => {
 		const ui = {
 			custom: async (factory: any) => {
 				const tui = { requestRender() {} };

--- a/test/ask-ui-interaction.test.ts
+++ b/test/ask-ui-interaction.test.ts
@@ -65,6 +65,33 @@ describe("askSingleQuestionWithInlineNote interactive branches", () => {
 		expect(result).toEqual({ selectedOptions: [], customInput: "custom-flow" });
 	});
 
+	it("cancels single-question flow on Ctrl-C, including from note editor", async () => {
+		const ui = {
+			custom: async (factory: any) => {
+				const tui = { requestRender() {} };
+				const theme = createFakeTheme();
+				let result: any;
+				const done = (value: any) => {
+					result = value;
+				};
+
+				const component = await factory(tui, theme, {}, done);
+				component.render(40);
+				component.handleInput("	");
+				component.handleInput("draft");
+				component.handleInput("");
+				return result;
+			},
+		} as unknown as ExtensionUIContext;
+
+		const result = await askSingleQuestionWithInlineNote(ui, {
+			question: "Choose one",
+			options: [{ label: "A" }, { label: "B" }],
+		});
+
+		expect(result).toEqual({ selectedOptions: [] });
+	});
+
 	it("handles navigation, inline edit exit, invalidate, and cancel", async () => {
 		const ui = {
 			custom: async (factory: any) => {
@@ -247,6 +274,64 @@ describe("askQuestionsWithTabs interactive branches", () => {
 		expect(result).toEqual({
 			cancelled: false,
 			selections: [{ selectedOptions: ["A"] }],
+		});
+	});
+
+	it("cancels tab flow on Ctrl-C from question, note editor, and submit tab", async () => {
+		const ui = {
+			custom: async (factory: any) => {
+				const tui = { requestRender() {} };
+				const theme = createFakeTheme();
+				let result: any;
+				const done = (value: any) => {
+					result = value;
+				};
+
+				const component = await factory(tui, theme, {}, done);
+				component.render(40);
+				component.handleInput("	");
+				component.handleInput("memo");
+				component.handleInput("");
+				return result;
+			},
+		} as unknown as ExtensionUIContext;
+
+		const result = await askQuestionsWithTabs(ui, [
+			{ id: "q1", question: "Question 1", options: [{ label: "A" }, { label: "B" }] },
+			{ id: "q2", question: "Question 2", options: [{ label: "C" }, { label: "D" }] },
+		]);
+
+		expect(result).toEqual({
+			cancelled: true,
+			selections: [{ selectedOptions: [] }, { selectedOptions: [] }],
+		});
+	});
+
+	it("cancels tab flow on Ctrl-C from submit tab", async () => {
+		const ui = {
+			custom: async (factory: any) => {
+				const tui = { requestRender() {} };
+				const theme = createFakeTheme();
+				let result: any;
+				const done = (value: any) => {
+					result = value;
+				};
+
+				const component = await factory(tui, theme, {}, done);
+				component.handleInput("\r");
+				component.handleInput("\u001b[C");
+				component.handleInput("\u0003");
+				return result;
+			},
+		} as unknown as ExtensionUIContext;
+
+		const result = await askQuestionsWithTabs(ui, [
+			{ id: "q1", question: "Question 1", options: [{ label: "A" }] },
+		]);
+
+		expect(result).toEqual({
+			cancelled: true,
+			selections: [{ selectedOptions: [] }],
 		});
 	});
 


### PR DESCRIPTION
## Summary
- make Ctrl-C cancel the ask flow in inline and tabbed UIs
- preserve existing Escape behavior for editor-local exit vs flow cancel
- add interaction coverage for Ctrl-C cancellation paths

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+C now immediately cancels interactions across interfaces, exiting note-editing and tab flows and returning a cancelled/empty-selection result.

* **Tests**
  * Added interactive tests covering Ctrl+C cancellation from note editor, tabs, and submit navigation to ensure cancellation propagates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->