### PR TITLE
Support Ctrl-N and Ctrl-P option navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ For `Other`, a note is required to become valid.
 
 ## Keyboard Shortcuts
 
-- `↑ / ↓`: move between options
+- `Ctrl+P` / `Ctrl+N` or `↑ / ↓`: move between options
 - `← / →`: switch question tabs
 - `Enter`: select/toggle or submit (on Submit tab)
 - `Tab`: start/stop inline note editing

--- a/src/ask-inline-ui.ts
+++ b/src/ask-inline-ui.ts
@@ -20,6 +20,10 @@ import { getLinearCursorIndexFromEditor } from "./ask-inline-editor-cursor";
 import { INLINE_NOTE_WRAP_PADDING, buildWrappedOptionLabelWithInlineNote } from "./ask-inline-note";
 import { appendWrappedTextLines } from "./ask-text-wrap";
 
+const isPreviousOptionKey = (data: string) => matchesKey(data, Key.ctrl("p")) || matchesKey(data, Key.up);
+const isNextOptionKey = (data: string) => matchesKey(data, Key.ctrl("n")) || matchesKey(data, Key.down);
+const isOptionNavigationKey = (data: string) => isPreviousOptionKey(data) || isNextOptionKey(data);
+
 interface SingleQuestionInput {
 	question: string;
 	description?: string;
@@ -200,9 +204,9 @@ export async function askSingleQuestionWithInlineNote(
 			if (isNoteEditorOpen) {
 				addLine(theme.fg("dim", " Typing note inline • Enter submit • Tab/Esc stop editing"));
 			} else if (getTrimmedNoteForOption(cursorOptionIndex).length > 0) {
-				addLine(theme.fg("dim", " ↑↓ move • Enter submit • Tab edit note • Esc cancel"));
+				addLine(theme.fg("dim", " Ctrl+P/N or ↑↓ move • Enter submit • Tab edit note • Esc cancel"));
 			} else {
-				addLine(theme.fg("dim", " ↑↓ move • Enter submit • Tab add note • Esc cancel"));
+				addLine(theme.fg("dim", " Ctrl+P/N or ↑↓ move • Enter submit • Tab add note • Esc cancel"));
 			}
 
 			addLine(theme.fg("accent", "─".repeat(width)));
@@ -224,10 +228,7 @@ export async function askSingleQuestionWithInlineNote(
 					return;
 				}
 
-				if (
-					(matchesKey(data, Key.up) || matchesKey(data, Key.down)) &&
-					getTrimmedNoteForOption(cursorOptionIndex).length === 0
-				) {
+				if (isOptionNavigationKey(data) && getTrimmedNoteForOption(cursorOptionIndex).length === 0) {
 					isNoteEditorOpen = false;
 				} else {
 					noteEditor.handleInput(data);
@@ -236,7 +237,7 @@ export async function askSingleQuestionWithInlineNote(
 				}
 			}
 
-			if (matchesKey(data, Key.up)) {
+			if (isPreviousOptionKey(data)) {
 				cursorOptionIndex = Math.max(0, cursorOptionIndex - 1);
 				if (selectableOptionLabels[cursorOptionIndex] === OTHER_OPTION) {
 					openNoteEditorForCurrentOption();
@@ -244,7 +245,7 @@ export async function askSingleQuestionWithInlineNote(
 				requestUiRerender();
 				return;
 			}
-			if (matchesKey(data, Key.down)) {
+			if (isNextOptionKey(data)) {
 				cursorOptionIndex = Math.min(selectableOptionLabels.length - 1, cursorOptionIndex + 1);
 				if (selectableOptionLabels[cursorOptionIndex] === OTHER_OPTION) {
 					openNoteEditorForCurrentOption();

--- a/src/ask-tabs-ui.ts
+++ b/src/ask-tabs-ui.ts
@@ -21,6 +21,10 @@ import { getLinearCursorIndexFromEditor } from "./ask-inline-editor-cursor";
 import { INLINE_NOTE_WRAP_PADDING, buildWrappedOptionLabelWithInlineNote } from "./ask-inline-note";
 import { appendWrappedTextLines } from "./ask-text-wrap";
 
+const isPreviousOptionKey = (data: string) => matchesKey(data, Key.ctrl("p")) || matchesKey(data, Key.up);
+const isNextOptionKey = (data: string) => matchesKey(data, Key.ctrl("n")) || matchesKey(data, Key.down);
+const isOptionNavigationKey = (data: string) => isPreviousOptionKey(data) || isNextOptionKey(data);
+
 interface PreparedQuestion {
 	id: string;
 	question: string;
@@ -404,12 +408,12 @@ export async function askQuestionsWithTabs(
 					addLine(
 						theme.fg(
 							"dim",
-							" ↑↓ move • Enter toggle/select • Tab add note • ←/→ switch tabs • Esc cancel",
+							" Ctrl+P/N or ↑↓ move • Enter toggle/select • Tab add note • ←/→ switch tabs • Esc cancel",
 						),
 					);
 				} else {
 					addLine(
-						theme.fg("dim", " ↑↓ move • Enter select • Tab add note • ←/→ switch tabs • Esc cancel"),
+						theme.fg("dim", " Ctrl+P/N or ↑↓ move • Enter select • Tab add note • ←/→ switch tabs • Esc cancel"),
 					);
 				}
 			}
@@ -453,10 +457,7 @@ export async function askQuestionsWithTabs(
 				const questionIndex = getActiveQuestionIndex();
 				const cursorOptionIndex = questionIndex == null ? 0 : cursorOptionIndexByQuestion[questionIndex];
 				const noteIsEmpty = questionIndex == null || getTrimmedQuestionNote(questionIndex, cursorOptionIndex).length === 0;
-				if (
-					noteIsEmpty &&
-					(matchesKey(data, Key.up) || matchesKey(data, Key.down) || matchesKey(data, Key.left) || matchesKey(data, Key.right))
-				) {
+				if (noteIsEmpty && (isOptionNavigationKey(data) || matchesKey(data, Key.left) || matchesKey(data, Key.right))) {
 					isNoteEditorOpen = false;
 				} else {
 					noteEditor.handleInput(data);
@@ -505,7 +506,7 @@ export async function askQuestionsWithTabs(
 			const questionIndex = activeTabIndex;
 			const preparedQuestion = preparedQuestions[questionIndex];
 
-			if (matchesKey(data, Key.up)) {
+			if (isPreviousOptionKey(data)) {
 				cursorOptionIndexByQuestion[questionIndex] = Math.max(0, cursorOptionIndexByQuestion[questionIndex] - 1);
 				if (preparedQuestion.options[cursorOptionIndexByQuestion[questionIndex]] === OTHER_OPTION) {
 					openNoteEditorForActiveOption();
@@ -515,7 +516,7 @@ export async function askQuestionsWithTabs(
 				return;
 			}
 
-			if (matchesKey(data, Key.down)) {
+			if (isNextOptionKey(data)) {
 				cursorOptionIndexByQuestion[questionIndex] = Math.min(
 					preparedQuestion.options.length - 1,
 					cursorOptionIndexByQuestion[questionIndex] + 1,

--- a/test/ask-ui-interaction.test.ts
+++ b/test/ask-ui-interaction.test.ts
@@ -192,6 +192,37 @@ describe("askSingleQuestionWithInlineNote interactive branches", () => {
 		expect(result).toEqual({ selectedOptions: [] });
 	});
 
+	it("moves inline selection with Ctrl-N and Ctrl-P", async () => {
+		const ui = {
+			custom: async (factory: any) => {
+				const tui = { requestRender() {} };
+				const theme = createFakeTheme();
+				let result: any;
+				const done = (value: any) => {
+					result = value;
+				};
+
+				const component = await factory(tui, theme, {}, done);
+				component.render(40);
+				component.handleInput("\u000e");
+				const afterCtrlN = component.render(40).join("\n");
+				expect(afterCtrlN).toContain("→ ● B");
+				component.handleInput("\u0010");
+				const afterCtrlP = component.render(40).join("\n");
+				expect(afterCtrlP).toContain("→ ● A");
+				component.handleInput("\r");
+				return result;
+			},
+		} as unknown as ExtensionUIContext;
+
+		const result = await askSingleQuestionWithInlineNote(ui, {
+			question: "Choose one",
+			options: [{ label: "A" }, { label: "B" }],
+		});
+
+		expect(result).toEqual({ selectedOptions: ["A"] });
+	});
+
 	it("submits selected predefined option with Enter", async () => {
 		const ui = {
 			custom: async (factory: any) => {
@@ -391,6 +422,41 @@ describe("askQuestionsWithTabs interactive branches", () => {
 		expect(result).toEqual({
 			cancelled: false,
 			selections: [{ selectedOptions: [], customInput: "edge-case" }],
+		});
+	});
+
+	it("moves tab selection with Ctrl-N and Ctrl-P", async () => {
+		const ui = {
+			custom: async (factory: any) => {
+				const tui = { requestRender() {} };
+				const theme = createFakeTheme();
+				let result: any;
+				const done = (value: any) => {
+					result = value;
+				};
+
+				const component = await factory(tui, theme, {}, done);
+				component.render(40);
+				component.handleInput("\u000e");
+				const afterCtrlN = component.render(40).join("\n");
+				expect(afterCtrlN).toContain("→ ○ B");
+				component.handleInput("\u0010");
+				const afterCtrlP = component.render(40).join("\n");
+				expect(afterCtrlP).toContain("→ ○ A");
+				component.handleInput("\r");
+				component.render(40);
+				component.handleInput("\r");
+				return result;
+			},
+		} as unknown as ExtensionUIContext;
+
+		const result = await askQuestionsWithTabs(ui, [
+			{ id: "single_nav", question: "Single question", options: [{ label: "A" }, { label: "B" }] },
+		]);
+
+		expect(result).toEqual({
+			cancelled: false,
+			selections: [{ selectedOptions: ["A"] }],
 		});
 	});
 


### PR DESCRIPTION
## Summary

Adds Ctrl-N and Ctrl-P as option navigation aliases while keeping the existing arrow key behavior. This works in both the inline single-question UI and the tabbed question UI.

## Changes

- Add Ctrl-N for next option and Ctrl-P for previous option
- Keep Up and Down arrow navigation unchanged
- Update footer hints and README shortcut docs
- Add interaction tests for both UI flows

## Test

```bash
npm run check
```